### PR TITLE
fix: Use correct PAT

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -14,11 +14,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          token: "${{ secrets.P_ACCESS_TOKEN }}"
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.P_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Description of Changes

- Uses the correct github personal access token (not the one created by Roderick Go). The old token had expired with his departure, and so the github actions were failing.


## Requester Checklist
(For person creating this PR to complete)
- [X] Completed all sections of pull request template
- [X] Removed any unnecessary data files
- [X] Added relevant documentation (in `./docs` folder)
- [X] Updated UI elements as-needed to reflect code layer changes
- [X] Merge remote `main` branch into this branch to confirm changes work with latest version of `main`


## Reviewer Checklist
(For reviewer to complete. Do not approve this PR until **all** checklist items completed.)
- [x] Confirm requester has completed all PR template checks (above) correctly & completely
